### PR TITLE
Add dark mode toggle feature replacing GitHub link in header

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
+import { ThemeProvider } from "@/components/theme-provider";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -25,11 +26,18 @@ export default function RootLayout({
 }>) {
   return (
     <ClerkProvider>
-      <html lang="en">
+      <html lang="en" suppressHydrationWarning>
         <body
           className={`${geistSans.variable} ${geistMono.variable} antialiased`}
         >
-          {children}
+          <ThemeProvider
+            attribute="class"
+            defaultTheme="system"
+            enableSystem
+            disableTransitionOnChange
+          >
+            {children}
+          </ThemeProvider>
         </body>
       </html>
     </ClerkProvider>

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,7 +1,7 @@
 "use client";
-import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
 import { SidebarTrigger } from "@/components/ui/sidebar"
+import { ThemeToggle } from "@/components/theme-toggle"
 
 export function SiteHeader() {
   return (
@@ -14,16 +14,7 @@ export function SiteHeader() {
         />
         <h1 className="text-base font-medium">Documents</h1>
         <div className="ml-auto flex items-center gap-2">
-          <Button variant="ghost" asChild size="sm" className="hidden sm:flex">
-            <a
-              href="https://github.com/shadcn-ui/ui/tree/main/apps/v4/app/(examples)/dashboard"
-              rel="noopener noreferrer"
-              target="_blank"
-              className="dark:text-foreground"
-            >
-              GitHub
-            </a>
-          </Button>
+          <ThemeToggle />
         </div>
       </div>
     </header>

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,8 @@
+"use client"
+
+import * as React from "react"
+import { ThemeProvider as NextThemesProvider, type ThemeProviderProps } from "next-themes"
+
+export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import * as React from "react"
+import { Moon, Sun, Monitor } from "lucide-react"
+import { useTheme } from "next-themes"
+
+import { Button } from "@/components/ui/button"
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+  
+  // Function to cycle through themes: light -> dark -> system -> light
+  const cycleTheme = () => {
+    if (theme === 'light') {
+      setTheme('dark')
+    } else if (theme === 'dark') {
+      setTheme('system')
+    } else {
+      setTheme('light')
+    }
+  }
+
+  return (
+    <Button 
+      variant="ghost" 
+      size="sm" 
+      className="h-8 w-8 px-0" 
+      onClick={cycleTheme}
+    >
+      {theme === 'light' && <Sun className="h-[1.2rem] w-[1.2rem]" />}
+      {theme === 'dark' && <Moon className="h-[1.2rem] w-[1.2rem]" />}
+      {(theme === 'system' || !theme) && <Monitor className="h-[1.2rem] w-[1.2rem]" />}
+      <span className="sr-only">
+        {theme === 'light' ? 'Switch to dark mode' : 
+         theme === 'dark' ? 'Switch to system mode' : 'Switch to light mode'}
+      </span>
+    </Button>
+  )
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,76 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: ["class"],
+  content: [
+    './pages/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+    './app/**/*.{ts,tsx}',
+    './src/**/*.{ts,tsx}',
+  ],
+  theme: {
+    container: {
+      center: true,
+      padding: "2rem",
+      screens: {
+        "2xl": "1400px",
+      },
+    },
+    extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      keyframes: {
+        "accordion-down": {
+          from: { height: 0 },
+          to: { height: "var(--radix-accordion-content-height)" },
+        },
+        "accordion-up": {
+          from: { height: "var(--radix-accordion-content-height)" },
+          to: { height: 0 },
+        },
+      },
+      animation: {
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out",
+      },
+    },
+  },
+  plugins: [],
+}


### PR DESCRIPTION
This pull request introduces a theme toggle feature and updates the layout to support theme switching. The main changes include adding a `ThemeProvider` component, implementing a `ThemeToggle` button, and updating the `RootLayout` and `SiteHeader` components to integrate the new theme functionality.

Theme support implementation:

* [`src/app/layout.tsx`](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R4): Added `ThemeProvider` to manage theme settings and updated the `RootLayout` to include the `ThemeProvider` component. [[1]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R4) [[2]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L28-R40)
* [`src/components/theme-provider.tsx`](diffhunk://#diff-41578ab9c9e0cf8349d184c064ea7f0fff8f79b6bc9f5cc118305d1912e413dfR1-R8): Created a new `ThemeProvider` component to wrap the `NextThemesProvider` and handle theme properties.
* [`src/components/theme-toggle.tsx`](diffhunk://#diff-c578fdeec3b6c79c5fd9967c8ee8191ecf25a6a66c30e29b01c317b71a58f9b3R1-R39): Implemented the `ThemeToggle` component, which provides a button to cycle through light, dark, and system themes.

Integration with existing components:

* [`src/components/site-header.tsx`](diffhunk://#diff-3de2e2ca7d47ee39efc8499eb66f3b4d4d2a73eb47edb53752f099bce158b59eL2-R4): Replaced the GitHub button with the new `ThemeToggle` button in the `SiteHeader` component. [[1]](diffhunk://#diff-3de2e2ca7d47ee39efc8499eb66f3b4d4d2a73eb47edb53752f099bce158b59eL2-R4) [[2]](diffhunk://#diff-3de2e2ca7d47ee39efc8499eb66f3b4d4d2a73eb47edb53752f099bce158b59eL17-R17)